### PR TITLE
added support for Default Dark+ theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Standard ML Support for Visual Studio Code
 
 ### Syntax Themes
 
-Currently only Tomorrow/Solarized/Gruvbox/Oceanic/Abyss Themes are supported.
+Currently only Tomorrow/Solarized/Gruvbox/Oceanic/Abyss/Default Dark+ Themes are supported.

--- a/src/scoping.ts
+++ b/src/scoping.ts
@@ -120,6 +120,18 @@ export async function load() {
 					purple: '#B294BB',
 				});
 				break;
+			case "Default Dark+":
+				setColors({
+					comment: '#6A9955',
+					red: '#CC6666',
+					orange: '#b5cea8',
+					yellow: '#F0C674',
+					green: '#ce9178',
+					aqua: '#8ABEB7',
+					blue: '#DCDCAA',
+					purple: '#569cd6',
+				});
+				break;
 			case 'Tomorrow':
 			case 'Tomorrow Operator Mono':
 				setColors({


### PR DESCRIPTION
Hi, 
I've been using the Default Dark+ theme in vscode which this extension did not support previously, I have updated the README.md and scoping.ts to support the theme. 
This is my first contribution to a open source project so please correct me if I have done something wrong